### PR TITLE
Github app integration implemented

### DIFF
--- a/.github/workflows/azure-publish.yaml
+++ b/.github/workflows/azure-publish.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - github-app
 
 jobs:
   publish:

--- a/.github/workflows/azure-publish.yaml
+++ b/.github/workflows/azure-publish.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - github-app
 
 jobs:
   publish:

--- a/.github/workflows/azure-publish.yaml
+++ b/.github/workflows/azure-publish.yaml
@@ -11,14 +11,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           fetch-depth: 1
 
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "3.0.100"
+          dotnet-version: "3.1.300"
 
       - name: "Run dotnet build"
         shell: bash

--- a/src/EventHandlers/BranchCreatedEventHandler.cs
+++ b/src/EventHandlers/BranchCreatedEventHandler.cs
@@ -9,12 +9,12 @@ namespace Ahk.GitHub.Monitor.EventHandlers
         public const string GitHubWebhookEventName = "create";
         public const string FeatureFlagName = "AHK_BRANCHPROTECTION_ENABLED";
 
-        public BranchCreatedEventHandler(GitHubClient gitHubClient)
-            : base(gitHubClient, FeatureFlagName)
+        public BranchCreatedEventHandler()
+            : base(FeatureFlagName)
         {
         }
 
-        protected override async Task execute(CreateEventPayload webhookPayload, WebhookResult webhookResult)
+        protected override async Task execute(GitHubClient gitHubClient, CreateEventPayload webhookPayload, WebhookResult webhookResult)
         {
             if (webhookPayload.RefType.StringValue.Equals("branch", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/EventHandlers/IssueCommentEventHandler.cs
+++ b/src/EventHandlers/IssueCommentEventHandler.cs
@@ -9,12 +9,12 @@ namespace Ahk.GitHub.Monitor.EventHandlers
         public const string GitHubWebhookEventName = "issue_comment";
         public const string FeatureFlagName = "AHK_COMMENTEDITWARN_ENABLED";
 
-        public IssueCommentEventHandler(GitHubClient gitHubClient)
-            : base(gitHubClient, FeatureFlagName)
+        public IssueCommentEventHandler()
+            : base(FeatureFlagName)
         {
         }
 
-        protected override async Task execute(IssueCommentPayload webhookPayload, WebhookResult webhookResult)
+        protected override async Task execute(GitHubClient gitHubClient, IssueCommentPayload webhookPayload, WebhookResult webhookResult)
         {
             if (webhookPayload.Issue == null)
             {

--- a/src/EventHandlers/PullRequestEventHandler.cs
+++ b/src/EventHandlers/PullRequestEventHandler.cs
@@ -11,12 +11,12 @@ namespace Ahk.GitHub.Monitor.EventHandlers
         public const string GitHubWebhookEventName = "pull_request";
         public const string FeatureFlagName = "AHK_ONEPULLREQUEST_ENABLED";
 
-        public PullRequestEventHandler(GitHubClient gitHubClient)
-            : base(gitHubClient, FeatureFlagName)
+        public PullRequestEventHandler()
+            : base(FeatureFlagName)
         {
         }
 
-        protected override async Task execute(PullRequestEventPayload webhookPayload, WebhookResult webhookResult)
+        protected override async Task execute(GitHubClient gitHubClient, PullRequestEventPayload webhookPayload, WebhookResult webhookResult)
         {
             if (webhookPayload.PullRequest == null)
             {

--- a/src/EventHandlers/RepositoryEventBase.cs
+++ b/src/EventHandlers/RepositoryEventBase.cs
@@ -8,12 +8,10 @@ namespace Ahk.GitHub.Monitor.EventHandlers
     public abstract class RepositoryEventBase<TPayload>
             where TPayload : ActivityPayload
     {
-        protected readonly GitHubClient gitHubClient;
         private readonly string featureFlagName;
 
-        protected RepositoryEventBase(GitHubClient gitHubClient, string featureFlagName)
+        protected RepositoryEventBase(string featureFlagName)
         {
-            this.gitHubClient = gitHubClient ?? throw new ArgumentNullException(nameof(gitHubClient));
             this.featureFlagName = featureFlagName;
         }
 
@@ -34,10 +32,11 @@ namespace Ahk.GitHub.Monitor.EventHandlers
                 return;
             }
 
-            await execute(webhookPayload, webhookResult);
+            var gitHubClient = await GitHubClientHelper.CreateGitHubClient(webhookPayload.Installation.Id);
+            await execute(gitHubClient, webhookPayload, webhookResult);
         }
 
-        protected abstract Task execute(TPayload webhookPayload1, WebhookResult webhookResult);
+        protected abstract Task execute(GitHubClient gitHubClient, TPayload webhookPayload, WebhookResult webhookResult);
 
         protected bool tryParsePayload(string requestBody, WebhookResult webhookResult, out TPayload payload)
         {

--- a/src/Extensions/DateTimeExtensions.cs
+++ b/src/Extensions/DateTimeExtensions.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Ahk.GitHub.Monitor.Extensions
 {

--- a/src/Extensions/DateTimeExtensions.cs
+++ b/src/Extensions/DateTimeExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ahk.GitHub.Monitor.Extensions
+{
+    static class DateTimeExtensions
+    {
+        private static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        public static int ToUnixTimeStamp(this DateTime date)
+        {
+            return (int)(date - UnixEpoch).TotalSeconds;
+        }
+    }
+}

--- a/src/GitHubMonitorFunction.cs
+++ b/src/GitHubMonitorFunction.cs
@@ -15,12 +15,6 @@ namespace Ahk.GitHub.Monitor
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = null)] HttpRequest request,
             ILogger logger)
         {
-            var githubToken = Environment.GetEnvironmentVariable("AHK_GITHUB_TOKEN", EnvironmentVariableTarget.Process);
-            if (string.IsNullOrEmpty(githubToken))
-            {
-                return new ObjectResult(new { error = "GitHub access token not configured" }) { StatusCode = StatusCodes.Status500InternalServerError };
-            }
-
             var githubSecret = Environment.GetEnvironmentVariable("AHK_GITHUB_SECRET", EnvironmentVariableTarget.Process);
             if (string.IsNullOrEmpty(githubSecret))
             {
@@ -43,7 +37,7 @@ namespace Ahk.GitHub.Monitor
                 var webhookResult = new WebhookResult();
                 try
                 {
-                    var gitHubClient = GitHubClientHelper.CreateGitHubClient(githubToken);
+                    var gitHubClient = await GitHubClientHelper.CreateGitHubClient();
                     string requestBody = payload.ReadAsString();
                     switch (eventName)
                     {

--- a/src/GitHubMonitorFunction.cs
+++ b/src/GitHubMonitorFunction.cs
@@ -21,6 +21,13 @@ namespace Ahk.GitHub.Monitor
                 return new ObjectResult(new { error = "GitHub secret not configured" }) { StatusCode = StatusCodes.Status500InternalServerError };
             }
 
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AHK_GITHUB_APP_PRIVATE_KEY", EnvironmentVariableTarget.Process))
+                || string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AHK_GITHUB_APP_INSTALLATION_ID", EnvironmentVariableTarget.Process))
+                || string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AHK_GITHUB_APP_ID", EnvironmentVariableTarget.Process)))
+            {
+                return new ObjectResult(new { error = "GitHub App ID/Token not configured" }) { StatusCode = StatusCodes.Status500InternalServerError };
+            }
+
             string eventName = request.Headers.GetValueOrDefault("X-GitHub-Event");
             string deliveryId = request.Headers.GetValueOrDefault("X-GitHub-Delivery");
             string receivedSignature = request.Headers.GetValueOrDefault("X-Hub-Signature");

--- a/src/GitHubMonitorFunction.cs
+++ b/src/GitHubMonitorFunction.cs
@@ -22,7 +22,6 @@ namespace Ahk.GitHub.Monitor
             }
 
             if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AHK_GITHUB_APP_PRIVATE_KEY", EnvironmentVariableTarget.Process))
-                || string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AHK_GITHUB_APP_INSTALLATION_ID", EnvironmentVariableTarget.Process))
                 || string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AHK_GITHUB_APP_ID", EnvironmentVariableTarget.Process)))
             {
                 return new ObjectResult(new { error = "GitHub App ID/Token not configured" }) { StatusCode = StatusCodes.Status500InternalServerError };
@@ -44,18 +43,17 @@ namespace Ahk.GitHub.Monitor
                 var webhookResult = new WebhookResult();
                 try
                 {
-                    var gitHubClient = await GitHubClientHelper.CreateGitHubClient();
                     string requestBody = payload.ReadAsString();
                     switch (eventName)
                     {
                         case EventHandlers.BranchCreatedEventHandler.GitHubWebhookEventName:
-                            await new EventHandlers.BranchCreatedEventHandler(gitHubClient).Execute(requestBody, webhookResult);
+                            await new EventHandlers.BranchCreatedEventHandler().Execute(requestBody, webhookResult);
                             break;
                         case EventHandlers.IssueCommentEventHandler.GitHubWebhookEventName:
-                            await new EventHandlers.IssueCommentEventHandler(gitHubClient).Execute(requestBody, webhookResult);
+                            await new EventHandlers.IssueCommentEventHandler().Execute(requestBody, webhookResult);
                             break;
                         case EventHandlers.PullRequestEventHandler.GitHubWebhookEventName:
-                            await new EventHandlers.PullRequestEventHandler(gitHubClient).Execute(requestBody, webhookResult);
+                            await new EventHandlers.PullRequestEventHandler().Execute(requestBody, webhookResult);
                             break;
                         default:
                             webhookResult.LogInfo($"Event {eventName} is not of interrest");

--- a/src/Helpers/CryptoHelper.cs
+++ b/src/Helpers/CryptoHelper.cs
@@ -1,11 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
-using System.Text;
 
 namespace Ahk.GitHub.Monitor.Helpers
 {
+    /// <summary>
+    /// Based on https://thomaslevesque.com/2018/03/30/writing-a-github-webhook-as-an-azure-function/
+    /// </summary>
     static class CryptoHelper
     {
         public static RSAParameters GetRsaParameters(string privateKeyBase64)

--- a/src/Helpers/CryptoHelper.cs
+++ b/src/Helpers/CryptoHelper.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Ahk.GitHub.Monitor.Helpers
+{
+    static class CryptoHelper
+    {
+        public static RSAParameters GetRsaParameters(string privateKeyBase64)
+        {
+            byte[] privateKeyBytes = Convert.FromBase64String(privateKeyBase64);
+
+            using (var memoryStream = new MemoryStream(privateKeyBytes))
+            using (var binaryReader = new BinaryReader(memoryStream))
+            {
+                var twobytes = binaryReader.ReadUInt16();
+                if (twobytes == 0x8130)
+                    binaryReader.ReadByte();
+                else if (twobytes == 0x8230)
+                    binaryReader.ReadInt16();
+                else
+                    throw new CryptographicException("Wrong data");
+
+                twobytes = binaryReader.ReadUInt16();
+                if (twobytes != 0x0102)
+                    throw new CryptographicException("Wrong data");
+
+                var bt = binaryReader.ReadByte();
+                if (bt != 0x00)
+                    throw new CryptographicException("Wrong data");
+
+                var elements = GetIntegerSize(binaryReader);
+                var paramModulus = binaryReader.ReadBytes(elements);
+
+                elements = GetIntegerSize(binaryReader);
+                var paramE = binaryReader.ReadBytes(elements);
+
+                elements = GetIntegerSize(binaryReader);
+                var paramD = binaryReader.ReadBytes(elements);
+
+                elements = GetIntegerSize(binaryReader);
+                var paramP = binaryReader.ReadBytes(elements);
+
+                elements = GetIntegerSize(binaryReader);
+                var paramQ = binaryReader.ReadBytes(elements);
+
+                elements = GetIntegerSize(binaryReader);
+                var paramDP = binaryReader.ReadBytes(elements);
+
+                elements = GetIntegerSize(binaryReader);
+                var paramDQ = binaryReader.ReadBytes(elements);
+
+                elements = GetIntegerSize(binaryReader);
+                var paramIQ = binaryReader.ReadBytes(elements);
+
+                EnsureLength(ref paramD, 256);
+                EnsureLength(ref paramDP, 128);
+                EnsureLength(ref paramDQ, 128);
+                EnsureLength(ref paramE, 3);
+                EnsureLength(ref paramIQ, 128);
+                EnsureLength(ref paramModulus, 256);
+                EnsureLength(ref paramP, 128);
+                EnsureLength(ref paramQ, 128);
+
+                var rsaParameters = new RSAParameters
+                {
+                    Modulus = paramModulus,
+                    Exponent = paramE,
+                    D = paramD,
+                    P = paramP,
+                    Q = paramQ,
+                    DP = paramDP,
+                    DQ = paramDQ,
+                    InverseQ = paramIQ
+                };
+
+                return rsaParameters;
+            }
+        }
+
+        private static int GetIntegerSize(BinaryReader binary)
+        {
+            var bt = binary.ReadByte();
+
+            if (bt != 0x02)
+                return 0;
+
+            bt = binary.ReadByte();
+
+            int count;
+            if (bt == 0x81)
+            {
+                count = binary.ReadByte();
+            }
+            else if (bt == 0x82)
+            {
+                var highbyte = binary.ReadByte();
+                var lowbyte = binary.ReadByte();
+                byte[] modint = { lowbyte, highbyte, 0x00, 0x00 };
+                count = BitConverter.ToInt32(modint, 0);
+            }
+            else
+            {
+                count = bt;
+            }
+
+            while (binary.ReadByte() == 0x00)
+                count -= 1;
+
+            binary.BaseStream.Seek(-1, SeekOrigin.Current);
+
+            return count;
+        }
+
+        private static void EnsureLength(ref byte[] data, int desiredLength)
+        {
+            if (data == null || data.Length >= desiredLength)
+                return;
+
+            int zeros = desiredLength - data.Length;
+
+            byte[] newData = new byte[desiredLength];
+            Array.Copy(data, 0, newData, zeros, data.Length);
+
+            data = newData;
+        }
+    }
+}

--- a/src/Helpers/GitHubClientHelper.cs
+++ b/src/Helpers/GitHubClientHelper.cs
@@ -1,16 +1,76 @@
-﻿using Octokit;
-using Octokit.Internal;
+﻿using Ahk.GitHub.Monitor.Extensions;
+using Ahk.GitHub.Monitor.Helpers;
+using Microsoft.IdentityModel.Tokens;
+using Newtonsoft.Json.Linq;
+using Octokit;
 using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Threading.Tasks;
 
 namespace Ahk.GitHub.Monitor
 {
     public static class GitHubClientHelper
     {
-        public static GitHubClient CreateGitHubClient(string token)
+        public static async Task<GitHubClient> CreateGitHubClient()
         {
-            var gitHubClient = new GitHubClient(new ProductHeaderValue("Ahk"), new InMemoryCredentialStore(new Credentials(token)));
+            var gitHubClient = new GitHubClient(new Octokit.ProductHeaderValue("Ahk"))
+            {
+                Credentials = new Credentials(await GetInstallationToken())
+            };
             gitHubClient.SetRequestTimeout(TimeSpan.FromSeconds(5));
             return gitHubClient;
+        }
+
+        public static string GetApplicationToken()
+        {
+            var parameters = CryptoHelper.GetRsaParameters(Environment.GetEnvironmentVariable("AHK_GITHUB_APP_PRIVATE_KEY", EnvironmentVariableTarget.Process));
+            var key = new RsaSecurityKey(parameters);
+            var creds = new SigningCredentials(key, SecurityAlgorithms.RsaSha256);
+            var now = DateTime.UtcNow;
+            var token = new JwtSecurityToken(claims: new[]
+            {
+                new Claim("iat", now.ToUnixTimeStamp().ToString(), ClaimValueTypes.Integer),
+                new Claim("exp", now.AddMinutes(10).ToUnixTimeStamp().ToString(), ClaimValueTypes.Integer),
+                new Claim("iss", Environment.GetEnvironmentVariable("AHK_GITHUB_APP_ID", EnvironmentVariableTarget.Process), ClaimValueTypes.Integer)
+            },
+            signingCredentials: creds);
+
+            var jwt = new JwtSecurityTokenHandler().WriteToken(token);
+            return jwt;
+        }
+
+        public static async Task<string> GetInstallationToken()
+        {
+            var installationId = Environment.GetEnvironmentVariable("AHK_GITHUB_APP_INSTALLATION_ID", EnvironmentVariableTarget.Process);
+            var applicationToken = GetApplicationToken();
+            using (var client = new HttpClient())
+            {
+                var request = new HttpRequestMessage(HttpMethod.Post, $"https://api.github.com/installations/{installationId}/access_tokens")
+                {
+                    Headers =
+                    {
+                        Authorization = new AuthenticationHeaderValue("Bearer", applicationToken),
+                        UserAgent =
+                        {
+                            ProductInfoHeaderValue.Parse("Ahk"),
+                        },
+                        Accept =
+                        {
+                            MediaTypeWithQualityHeaderValue.Parse("application/vnd.github.machine-man-preview+json")
+                        }
+                    }
+                };
+                using (var response = await client.SendAsync(request))
+                {
+                    response.EnsureSuccessStatusCode();
+                    var json = await response.Content.ReadAsStringAsync();
+                    var obj = JObject.Parse(json);
+                    return obj["token"]?.Value<string>();
+                }
+            }
         }
     }
 }

--- a/src/ahk-github-monitor.csproj
+++ b/src/ahk-github-monitor.csproj
@@ -3,13 +3,12 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <RootNamespace>Ahk.GitHub.Monitor</RootNamespace>
-    <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.5.1" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.5" />
-    <PackageReference Include="Octokit" Version="0.46.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.6.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
+    <PackageReference Include="Octokit" Version="0.47.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.6.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/ahk-github-monitor.csproj
+++ b/src/ahk-github-monitor.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <RootNamespace>Ahk.GitHub.Monitor</RootNamespace>
   </PropertyGroup>

--- a/src/ahk-github-monitor.csproj
+++ b/src/ahk-github-monitor.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>Ahk.GitHub.Monitor</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.4" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.6.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
     <PackageReference Include="Octokit" Version="0.47.0" />

--- a/src/ahk-github-monitor.csproj
+++ b/src/ahk-github-monitor.csproj
@@ -3,10 +3,13 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <RootNamespace>Ahk.GitHub.Monitor</RootNamespace>
+    <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.5.1" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.5" />
     <PackageReference Include="Octokit" Version="0.46.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/ahk-github-monitor.csproj
+++ b/src/ahk-github-monitor.csproj
@@ -4,6 +4,11 @@
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <RootNamespace>Ahk.GitHub.Monitor</RootNamespace>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
+  </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.4" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.6.0" />
@@ -11,6 +16,7 @@
     <PackageReference Include="Octokit" Version="0.47.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.6.0" />
   </ItemGroup>
+  
   <ItemGroup>
     <None Update="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
Az alkalmazás mostmár Github App installation token-t használ Personal Access Token helyett. Ehhez 3 új Environment variable-re van szüksége:

- AHK_GITHUB_APP_ID:

![image](https://user-images.githubusercontent.com/9963251/81059659-221f3100-8ed1-11ea-8cc8-d95c250d2385.png)

- AHK_GITHUB_APP_INSTALLATION_ID:

![image](https://user-images.githubusercontent.com/9963251/81059861-98bc2e80-8ed1-11ea-8bff-87631a23a69c.png)

- AHK_GITHUB_APP_PRIVATE_KEY:

![image](https://user-images.githubusercontent.com/9963251/81059993-e2a51480-8ed1-11ea-8377-6383669a9abf.png)


A privát kulcsnak base64 formátumban kell lennie egy sorban, vagyis a PEM format fejlécét és a végét illetve a newline-okat ki kell törölni belőle.

Tesztelve lokálisan a nuget packagekkel volt probléma, ehhez kellett a:
`<_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>`
Remélhetőleg Azureon is működni fog.