### PR TITLE
"Other closed PRs" check not working

### DIFF
--- a/src/EventHandlers/BranchProtectionRuleHandler.cs
+++ b/src/EventHandlers/BranchProtectionRuleHandler.cs
@@ -13,7 +13,7 @@ namespace Ahk.GitHub.Monitor.EventHandlers
         {
         }
 
-        protected override async Task execute(GitHubClient gitHubClient, CreateEventPayload webhookPayload, RepositorySettings repoSettings, WebhookResult webhookResult)
+        protected override async Task execute(CreateEventPayload webhookPayload, RepositorySettings repoSettings, WebhookResult webhookResult)
         {
             if (!webhookPayload.RefType.StringValue.Equals("branch", StringComparison.OrdinalIgnoreCase))
             {
@@ -25,7 +25,7 @@ namespace Ahk.GitHub.Monitor.EventHandlers
             }
             else
             {
-                await gitHubClient.Repository.Branch.UpdateBranchProtection(
+                await GitHubClient.Repository.Branch.UpdateBranchProtection(
                             webhookPayload.Repository.Id, webhookPayload.Ref, getBranchProtectionSettingsUpdate(webhookPayload.Ref));
                 webhookResult.LogInfo("Branch protection rule applied.");
             }

--- a/src/EventHandlers/IssueCommentEditDeleteHandler.cs
+++ b/src/EventHandlers/IssueCommentEditDeleteHandler.cs
@@ -14,7 +14,7 @@ namespace Ahk.GitHub.Monitor.EventHandlers
         {
         }
 
-        protected override async Task execute(GitHubClient gitHubClient, IssueCommentPayload webhookPayload, RepositorySettings repoSettings, WebhookResult webhookResult)
+        protected override async Task execute(IssueCommentPayload webhookPayload, RepositorySettings repoSettings, WebhookResult webhookResult)
         {
             if (webhookPayload.Issue == null)
             {
@@ -32,7 +32,7 @@ namespace Ahk.GitHub.Monitor.EventHandlers
                 }
                 else
                 {
-                    await gitHubClient.Issue.Comment.Create(webhookPayload.Repository.Id, webhookPayload.Issue.Number, getWarningText(repoSettings.CommentProtection));
+                    await GitHubClient.Issue.Comment.Create(webhookPayload.Repository.Id, webhookPayload.Issue.Number, getWarningText(repoSettings.CommentProtection));
                     webhookResult.LogInfo("comment action handled");
                 }
             }

--- a/src/EventHandlers/PullRequestOpenDuplicateHandler.cs
+++ b/src/EventHandlers/PullRequestOpenDuplicateHandler.cs
@@ -76,7 +76,7 @@ namespace Ahk.GitHub.Monitor.EventHandlers
                 var prsClosedByNotStudent = new List<int>();
                 foreach (var otherClosedPr in closedPrs)
                 {
-                    if (await isPrClosedByNotStudent(webhookPayload, otherClosedPr.Number))
+                    if (await isPrClosedByNotStudent(webhookPayload, otherClosedPr))
                         prsClosedByNotStudent.Add(otherClosedPr.Number);
                 }
 
@@ -98,13 +98,12 @@ namespace Ahk.GitHub.Monitor.EventHandlers
             }
         }
 
-        private async Task<bool> isPrClosedByNotStudent(PullRequestEventPayload webhookPayload, int prNumber)
+        private async Task<bool> isPrClosedByNotStudent(PullRequestEventPayload webhookPayload, PullRequest pr)
         {
-            var issueEvents = await GitHubClient.Issue.Events.GetAllForIssue(webhookPayload.Repository.Id, prNumber);
+            var issueEvents = await GitHubClient.Issue.Events.GetAllForIssue(webhookPayload.Repository.Id, pr.Number);
             return issueEvents.Any(
-                e => e.Event == EventInfoState.Closed // closed event
-                && e.Issue?.PullRequest != null // related to a PR
-                && e.Actor?.Id != e.Issue.User.Id); // PR closed by someone other than the person who opened it -> student opened and teached closed PR
+                e => e.Event.Value == EventInfoState.Closed // closed event
+                     && e.Actor?.Id != pr.User.Id); // PR closed by someone other than the person who opened it -> student opened and teached closed PR
         }
 
         private static string getWarningText(MultiplePRProtectionSettings multiplePRProtection, int currentPrNumber, IEnumerable<int> foundPrNumbers)

--- a/src/EventHandlers/PullRequestOpenDuplicateHandler.cs
+++ b/src/EventHandlers/PullRequestOpenDuplicateHandler.cs
@@ -16,7 +16,7 @@ namespace Ahk.GitHub.Monitor.EventHandlers
         {
         }
 
-        protected override async Task execute(GitHubClient gitHubClient, PullRequestEventPayload webhookPayload, RepositorySettings repoSettings, WebhookResult webhookResult)
+        protected override async Task execute(PullRequestEventPayload webhookPayload, RepositorySettings repoSettings, WebhookResult webhookResult)
         {
             if (webhookPayload.PullRequest == null)
             {
@@ -28,12 +28,12 @@ namespace Ahk.GitHub.Monitor.EventHandlers
             }
             else if (webhookPayload.Action.Equals("opened", StringComparison.OrdinalIgnoreCase))
             {
-                var openPullRequests = await gitHubClient.PullRequest.GetAllForRepository(webhookPayload.Repository.Id, new PullRequestRequest() { State = ItemStateFilter.Open });
+                var openPullRequests = await GitHubClient.PullRequest.GetAllForRepository(webhookPayload.Repository.Id, new PullRequestRequest() { State = ItemStateFilter.Open });
                 if (openPullRequests.Count > 1)
                 {
                     var warningText = getWarningText(repoSettings.MultiplePRProtection, openPullRequests.Select(pr => pr.Number));
                     foreach (var openPullRequest in openPullRequests)
-                        await gitHubClient.Issue.Comment.Create(webhookPayload.Repository.Id, openPullRequest.Number, warningText);
+                        await GitHubClient.Issue.Comment.Create(webhookPayload.Repository.Id, openPullRequest.Number, warningText);
 
                     webhookResult.LogInfo("pull request open handled with multiple open PRs");
                 }
@@ -42,7 +42,7 @@ namespace Ahk.GitHub.Monitor.EventHandlers
                     webhookResult.LogInfo($"pull request open is ok, there are no other open PRs");
                 }
 
-                var allRepoEvents = await gitHubClient.Issue.Events.GetAllForRepository(webhookPayload.Repository.Id);
+                var allRepoEvents = await GitHubClient.Issue.Events.GetAllForRepository(webhookPayload.Repository.Id);
                 var prsClosedByNotStudent = allRepoEvents.Where(e =>
                         e.Event.Value == EventInfoState.Closed // closed event
                         && e.Issue != null && e.Issue.PullRequest != null // related to a PR
@@ -51,7 +51,7 @@ namespace Ahk.GitHub.Monitor.EventHandlers
                 if (prsClosedByNotStudent.Count > 0)
                 {
                     var warningText = getWarningText(repoSettings.MultiplePRProtection, prsClosedByNotStudent.Select(e => e.Issue.Number));
-                    await gitHubClient.Issue.Comment.Create(webhookPayload.Repository.Id, webhookPayload.Number, warningText);
+                    await GitHubClient.Issue.Comment.Create(webhookPayload.Repository.Id, webhookPayload.Number, warningText);
 
                     webhookResult.LogInfo("pull request open handled with alrady closed PRs");
                 }

--- a/src/EventHandlers/PullRequestOpenDuplicateHandler.cs
+++ b/src/EventHandlers/PullRequestOpenDuplicateHandler.cs
@@ -28,36 +28,15 @@ namespace Ahk.GitHub.Monitor.EventHandlers
             }
             else if (webhookPayload.Action.Equals("opened", StringComparison.OrdinalIgnoreCase))
             {
-                var openPullRequests = await GitHubClient.PullRequest.GetAllForRepository(webhookPayload.Repository.Id, new PullRequestRequest() { State = ItemStateFilter.Open });
-                if (openPullRequests.Count > 1)
+                var repositoryPrs = await getPullRequestsExceptCurrent(webhookPayload);
+                if (repositoryPrs.Count == 0)
                 {
-                    var warningText = getWarningText(repoSettings.MultiplePRProtection, openPullRequests.Select(pr => pr.Number));
-                    foreach (var openPullRequest in openPullRequests)
-                        await GitHubClient.Issue.Comment.Create(webhookPayload.Repository.Id, openPullRequest.Number, warningText);
-
-                    webhookResult.LogInfo("pull request open handled with multiple open PRs");
+                    webhookResult.LogInfo("pull request open is ok, there are no other PRs");
                 }
                 else
                 {
-                    webhookResult.LogInfo($"pull request open is ok, there are no other open PRs");
-                }
-
-                var allRepoEvents = await GitHubClient.Issue.Events.GetAllForRepository(webhookPayload.Repository.Id);
-                var prsClosedByNotStudent = allRepoEvents.Where(e =>
-                        e.Event.Value == EventInfoState.Closed // closed event
-                        && e.Issue != null && e.Issue.PullRequest != null // related to a PR
-                        && e.Actor.Id != e.Issue.User.Id) // PR closed by someone other than the person who opened it -> student opened and teached closed PR
-                    .ToList();
-                if (prsClosedByNotStudent.Count > 0)
-                {
-                    var warningText = getWarningText(repoSettings.MultiplePRProtection, prsClosedByNotStudent.Select(e => e.Issue.Number));
-                    await GitHubClient.Issue.Comment.Create(webhookPayload.Repository.Id, webhookPayload.Number, warningText);
-
-                    webhookResult.LogInfo("pull request open handled with alrady closed PRs");
-                }
-                else
-                {
-                    webhookResult.LogInfo($"pull request open is ok, there are no other evaluated PRs");
+                    await handleAnyOpenPrs(webhookPayload, repoSettings, webhookResult, repositoryPrs);
+                    await handleAnyClosedPrs(webhookPayload, repoSettings, webhookResult, repositoryPrs);
                 }
             }
             else
@@ -66,9 +45,71 @@ namespace Ahk.GitHub.Monitor.EventHandlers
             }
         }
 
+        private async Task<IReadOnlyCollection<PullRequest>> getPullRequestsExceptCurrent(PullRequestEventPayload webhookPayload)
+        {
+            var allPullRequests = await GitHubClient.PullRequest.GetAllForRepository(webhookPayload.Repository.Id, new PullRequestRequest() { State = ItemStateFilter.All });
+            return allPullRequests.Where(otherPr => otherPr.Number != webhookPayload.PullRequest.Number).ToList();
+        }
+
+        private async Task handleAnyOpenPrs(PullRequestEventPayload webhookPayload, RepositorySettings repoSettings, WebhookResult webhookResult, IReadOnlyCollection<PullRequest> repositoryPrs)
+        {
+            var otherOpenPrs = repositoryPrs.Where(otherPr => otherPr.State == ItemState.Open).ToList();
+            if (otherOpenPrs.Any())
+            {
+                var warningText = getWarningText(repoSettings.MultiplePRProtection, otherOpenPrs.Select(pr => pr.Number));
+                foreach (var openPullRequest in otherOpenPrs)
+                    await GitHubClient.Issue.Comment.Create(webhookPayload.Repository.Id, openPullRequest.Number, warningText);
+
+                webhookResult.LogInfo("pull request open handled with multiple open PRs");
+            }
+            else
+            {
+                webhookResult.LogInfo("pull request open is ok, there are no other open PRs");
+            }
+        }
+
+        private async Task handleAnyClosedPrs(PullRequestEventPayload webhookPayload, RepositorySettings repoSettings, WebhookResult webhookResult, IReadOnlyCollection<PullRequest> repositoryPrs)
+        {
+            var otherClosedPrs = repositoryPrs.Where(otherPr => otherPr.State == ItemState.Closed).ToList();
+            if (otherClosedPrs.Any())
+            {
+                var prsClosedByNotStudent = new List<int>();
+                foreach (var otherClosedPr in otherClosedPrs)
+                {
+                    if (await isPrClosedByNotStudent(webhookPayload, otherClosedPr.Number))
+                        prsClosedByNotStudent.Add(otherClosedPr.Number);
+                }
+
+                if (prsClosedByNotStudent.Any())
+                {
+                    var warningText = getWarningText(repoSettings.MultiplePRProtection, prsClosedByNotStudent);
+                    await GitHubClient.Issue.Comment.Create(webhookPayload.Repository.Id, webhookPayload.Number, warningText);
+
+                    webhookResult.LogInfo("pull request open handled with already closed PRs");
+                }
+                else
+                {
+                    webhookResult.LogInfo("pull request open is ok, there are no other evaluated PRs");
+                }
+            }
+            else
+            {
+                webhookResult.LogInfo("pull request open is ok, there are no other closed PRs");
+            }
+        }
+
+        private async Task<bool> isPrClosedByNotStudent(PullRequestEventPayload webhookPayload, int prNumber)
+        {
+            var issueEvents = await GitHubClient.Issue.Events.GetAllForIssue(webhookPayload.Repository.Id, prNumber);
+            return issueEvents.Any(
+                e => e.Event == EventInfoState.Closed // closed event
+                && e.Issue?.PullRequest != null // related to a PR
+                && e.Actor?.Id != e.Issue.User.Id); // PR closed by someone other than the person who opened it -> student opened and teached closed PR
+        }
+
         private static string getWarningText(MultiplePRProtectionSettings multiplePRProtection, IEnumerable<int> referencedPullRequestNumbers)
         {
-            var prReferencesText = string.Join(" ", referencedPullRequestNumbers.OrderBy(num => num).Select(n => $"#{n}").ToArray());
+            var prReferencesText = string.Join(" ", referencedPullRequestNumbers.Distinct().OrderBy(num => num).Select(n => $"#{n}").ToArray());
             var effectiveWarningText = string.IsNullOrEmpty(multiplePRProtection.WarningText) ? DefaultWarningText : multiplePRProtection.WarningText;
             return effectiveWarningText.Replace("{}", prReferencesText);
         }


### PR DESCRIPTION
Output of the webhook

```
{"status":"failed","messages":["pull request open is ok, there are no other open PRs","Failed to handle webhook - Resource not accessible by integration"]}
```

Apparently, listing all events of a repository is not available for GitHub App.