### PR TITLE
Recognize repository default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ The application enforces the following rules.
 
 ### Branch usage
 
-1. The master branch is not touched by the student. The solution is submitted on a new branch via a pull request.
+1. The default branch is not touched by the student. The solution is submitted on a new branch via a pull request.
 1. There are no force pushes.
 
-These rules are enforced by marking all branches as protected, and requiring review of pull requests targeting the master branch.
+These rules are enforced by marking all branches as protected, and requiring review of pull requests targeting the default branch.
 
 This rule is enabled by default. The rule can be configured in the repository settings file:
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The application requires the following configurations specified as **environment
 
 The application reads a yaml configuration file stored in the GitHub repository triggering the events. The configuration file is used to enable the functionalities of this application as follows.
 
-The configuration file must be stored on the `master` branch in file `.github/ahk-monitor.yml`.
+The configuration file must be stored on the default branch in file `.github/ahk-monitor.yml`.
 
 The configuration file:
 

--- a/src/EventHandlers/BranchProtectionRuleHandler.cs
+++ b/src/EventHandlers/BranchProtectionRuleHandler.cs
@@ -26,25 +26,25 @@ namespace Ahk.GitHub.Monitor.EventHandlers
             else
             {
                 await GitHubClient.Repository.Branch.UpdateBranchProtection(
-                            webhookPayload.Repository.Id, webhookPayload.Ref, getBranchProtectionSettingsUpdate(webhookPayload.Ref));
+                            webhookPayload.Repository.Id, webhookPayload.Ref, getBranchProtectionSettingsUpdate(webhookPayload.Ref, webhookPayload.Repository.DefaultBranch));
                 webhookResult.LogInfo("Branch protection rule applied.");
             }
         }
 
-        private static BranchProtectionSettingsUpdate getBranchProtectionSettingsUpdate(string branchName)
+        private static BranchProtectionSettingsUpdate getBranchProtectionSettingsUpdate(string branchName, string repositoryDefaultBranch)
         {
-            // For master: prohibits the merge request into master to be merged
+            // For default: prohibits the merge request into default to be merged
             // For other branches: disables force push
             return new BranchProtectionSettingsUpdate(
                                     requiredStatusChecks: null, // Required. Require status checks to pass before merging. Set to null to disable.
-                                    requiredPullRequestReviews: getBranchProtectionRequiredReviewsUpdate(branchName),
+                                    requiredPullRequestReviews: getBranchProtectionRequiredReviewsUpdate(branchName, repositoryDefaultBranch),
                                     restrictions: null, // Push access restrictions. Null to disable.
                                     enforceAdmins: false); // Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
         }
 
-        private static BranchProtectionRequiredReviewsUpdate getBranchProtectionRequiredReviewsUpdate(string branchName)
+        private static BranchProtectionRequiredReviewsUpdate getBranchProtectionRequiredReviewsUpdate(string branchName, string repositoryDefaultBranch)
         {
-            if (branchName.Equals("master", StringComparison.OrdinalIgnoreCase))
+            if (branchName.Equals(repositoryDefaultBranch, StringComparison.OrdinalIgnoreCase))
                 return new BranchProtectionRequiredReviewsUpdate(false, false, 1); // Prohibits the student from merging the pull request.
             else
                 return null;

--- a/src/EventHandlers/RepositoryEventBase.cs
+++ b/src/EventHandlers/RepositoryEventBase.cs
@@ -87,7 +87,7 @@ namespace Ahk.GitHub.Monitor.EventHandlers
         {
             try
             {
-                var contents = await GitHubClient.Repository.Content.GetAllContentsByRef(webhookPayload.Repository.Id, ".github/ahk-monitor.yml", "master");
+                var contents = await GitHubClient.Repository.Content.GetAllContentsByRef(webhookPayload.Repository.Id, ".github/ahk-monitor.yml", webhookPayload.Repository.DefaultBranch);
                 var settingsString = contents.FirstOrDefault()?.Content;
 
                 if (settingsString == null)


### PR DESCRIPTION
`master` is no longer the default branch; use the default branch information from the webhook payload repository information