### PR TITLE
Duplicate open PR check: add warning to all open PRs

### DIFF
--- a/src/Ahk.GitHub.Monitor.Tests/UnitTests/EventHandlersTests/PullRequestOpenDuplicateHandlerTest.cs
+++ b/src/Ahk.GitHub.Monitor.Tests/UnitTests/EventHandlersTests/PullRequestOpenDuplicateHandlerTest.cs
@@ -61,15 +61,19 @@ namespace Ahk.GitHub.Monitor.Tests.UnitTests.EventHandlersTests
         public async Task OtherOpenPullRequestYieldsWarning()
         {
             var gitHubMock = GitHubClientMockFactory.CreateDefault()
-                                .WithPullRequestGetAll(c => c.ReturnsAsync(new[] { GitHubMockData.CreatePullRequest(324, Octokit.ItemState.Open, 111) }));
+                                .WithPullRequestGetAll(c => c.ReturnsAsync(new[]
+                                        {
+                                            GitHubMockData.CreatePullRequest(189, Octokit.ItemState.Open, 111),
+                                            GitHubMockData.CreatePullRequest(324, Octokit.ItemState.Open, 111),
+                                        }));
 
             var eh = new PullRequestOpenDuplicateHandler(gitHubMock.CreateFactory());
             var result = await eh.Execute(SampleData.PrOpen);
 
             Assert.IsTrue(result.Result.Contains("multiple open PRs"));
-            //gitHubMock.GitHubClientMock.Verify(c =>
-            //    c.Issue.Comment.Create(339316008, 189, It.IsAny<string>()),
-            //    Times.Once());
+            gitHubMock.GitHubClientMock.Verify(c =>
+                c.Issue.Comment.Create(339316008, 189, It.IsAny<string>()),
+                Times.Once());
             gitHubMock.GitHubClientMock.Verify(c =>
                 c.Issue.Comment.Create(339316008, 324, It.IsAny<string>()),
                 Times.Once());
@@ -79,7 +83,11 @@ namespace Ahk.GitHub.Monitor.Tests.UnitTests.EventHandlersTests
         public async Task OtherClosedPullRequestYieldsWarning()
         {
             var gitHubMock = GitHubClientMockFactory.CreateDefault()
-                                .WithPullRequestGetAll(c => c.ReturnsAsync(new[] { GitHubMockData.CreatePullRequest(23, Octokit.ItemState.Closed, 556677) }))
+                                .WithPullRequestGetAll(c => c.ReturnsAsync(new[]
+                                        {
+                                            GitHubMockData.CreatePullRequest(189, Octokit.ItemState.Open, 556677),
+                                            GitHubMockData.CreatePullRequest(23, Octokit.ItemState.Closed, 556677),
+                                        }))
                                 .WithIssueEventGetAll(c => c.ReturnsAsync(new[] { GitHubMockData.CreateIssueEvent(Octokit.EventInfoState.Closed, 444444) }));
 
             var eh = new PullRequestOpenDuplicateHandler(gitHubMock.CreateFactory());
@@ -89,16 +97,17 @@ namespace Ahk.GitHub.Monitor.Tests.UnitTests.EventHandlersTests
             gitHubMock.GitHubClientMock.Verify(c =>
                 c.Issue.Comment.Create(339316008, 189, It.IsAny<string>()),
                 Times.Once());
-            //gitHubMock.GitHubClientMock.Verify(c =>
-            //    c.Issue.Comment.Create(339316008, 23, It.IsAny<string>()),
-            //    Times.Once());
         }
 
         [TestMethod]
         public async Task OtherClosedPullRequestByOwnerYieldsNoWarning()
         {
             var gitHubMock = GitHubClientMockFactory.CreateDefault()
-                                .WithPullRequestGetAll(c => c.ReturnsAsync(new[] { GitHubMockData.CreatePullRequest(23, Octokit.ItemState.Closed, 556677) }))
+                                .WithPullRequestGetAll(c => c.ReturnsAsync(new[]
+                                        {
+                                            GitHubMockData.CreatePullRequest(23, Octokit.ItemState.Closed, 556677),
+                                            GitHubMockData.CreatePullRequest(189, Octokit.ItemState.Open, 556677),
+                                        }))
                                 .WithIssueEventGetAll(c => c.ReturnsAsync(new[] { GitHubMockData.CreateIssueEvent(Octokit.EventInfoState.Closed, 556677) }));
 
             var eh = new PullRequestOpenDuplicateHandler(gitHubMock.CreateFactory());


### PR DESCRIPTION
Checking for duplicate pull requests adds warning to all open PRs (previously added warning text to all but the newly opened one)